### PR TITLE
Reproduce `lerna version` formatting change to `package.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2965,6 +2965,10 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true
     },
+    "node_modules/example-lerna-formatting": {
+      "resolved": "packages/example_package",
+      "link": true
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -7441,6 +7445,9 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "packages/example_package": {
+      "version": "0.0.1"
     }
   },
   "dependencies": {
@@ -9783,6 +9790,9 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true
+    },
+    "example-lerna-formatting": {
+      "version": "file:packages/example_package"
     },
     "execa": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -6,5 +6,8 @@
   ],
   "devDependencies": {
     "lerna": "^6.3.0"
+  },
+  "scripts": {
+    "version": "lerna version patch --yes"
   }
 }

--- a/packages/example_package/package.json
+++ b/packages/example_package/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "example-lerna-formatting",
+  "version": "0.0.1",
+  "type": "module",
+  "files": ["dist"]
+}


### PR DESCRIPTION
This demonstrates how to reproduce the formatting change referenced by https://github.com/lerna/lerna/issues/4117

Reproduce the issue by running `npm run version`.  You will notice that the formatting of the "files" array has changed from a single-line array to a multi-line array.

Before(left)/After(right):
<img width="997" alt="Screenshot 2024-11-12 at 15 18 40" src="https://github.com/user-attachments/assets/a8552c7c-4907-4343-9189-f3534b375206">
